### PR TITLE
Enable filtering busbar sections equipments in the global filter, using voltage level filters in the generic filters category.

### DIFF
--- a/src/main/java/org/gridsuite/filter/globalfilter/GlobalFilterUtils.java
+++ b/src/main/java/org/gridsuite/filter/globalfilter/GlobalFilterUtils.java
@@ -149,12 +149,15 @@ public final class GlobalFilterUtils {
                                                             @Nonnull final EquipmentType actualType) {
         final List<AbstractExpertRule> rules = new ArrayList<>();
 
-        // Create only one OR rule for all filters with same type
+        // Create only one OR rule for all filters with same type (except special case of BUSBAR_SECTION type with voltage level filters)
         List<AbstractFilter> typeMatches = genericFilters.stream()
-                .filter(abstractFilter -> abstractFilter.getEquipmentType() == actualType)
+                .filter(abstractFilter -> abstractFilter.getEquipmentType() == actualType ||
+                    actualType == EquipmentType.BUSBAR_SECTION && abstractFilter.getEquipmentType() == EquipmentType.VOLTAGE_LEVEL)
                 .toList();
 
-        AbstractExpertRule typeMatchesRule = createFilterBasedRule(typeMatches, Set.of(FieldType.ID));
+        // for BUSBAR_SECTION type, we build a rule based on the voltage level id instead of the id
+        AbstractExpertRule typeMatchesRule = createFilterBasedRule(typeMatches,
+            actualType != EquipmentType.BUSBAR_SECTION ? Set.of(FieldType.ID) : Set.of(FieldType.VOLTAGE_LEVEL_ID));
         if (typeMatchesRule != null) {
             rules.add(typeMatchesRule);
         }
@@ -317,13 +320,18 @@ public final class GlobalFilterUtils {
             // (it is present in genericFilters OR there isn't any other equipment type in genericFilters))
 
             // all effective equipment types in genericFilters
+            //
+            // Special case : we can filter busbar sections with voltage level filters
+            // (for security analysis n-k results filtering on busbar sections contingencies)
             List<EquipmentType> equipmentTypesInGenericFilters = genericFilters.stream()
-                    .map(AbstractFilter::getEquipmentType)
-                    .filter(elem ->
-                            elem != EquipmentType.SUBSTATION &&
-                            elem != EquipmentType.VOLTAGE_LEVEL)
-                    .distinct().toList();
+                .map(AbstractFilter::getEquipmentType)
+                .filter(elem ->
+                    elem != EquipmentType.SUBSTATION &&
+                        (elem != EquipmentType.VOLTAGE_LEVEL || equipmentType == EquipmentType.BUSBAR_SECTION))
+                .distinct().toList();
+            boolean canFilterBusbarSectionsWithVoltageLevelFilter = equipmentTypesInGenericFilters.contains(EquipmentType.VOLTAGE_LEVEL) && equipmentType == EquipmentType.BUSBAR_SECTION;
             return equipmentTypesInGenericFilters.contains(equipmentType) ||
+                   canFilterBusbarSectionsWithVoltageLevelFilter ||
                    CollectionUtils.isEmpty(equipmentTypesInGenericFilters);
         }
     }

--- a/src/main/java/org/gridsuite/filter/utils/expertfilter/ExpertFilterUtils.java
+++ b/src/main/java/org/gridsuite/filter/utils/expertfilter/ExpertFilterUtils.java
@@ -50,7 +50,7 @@ public final class ExpertFilterUtils {
                 case LOAD -> getLoadFieldValue(field, propertyName, (Load) identifiable);
                 case SHUNT_COMPENSATOR -> getShuntCompensatorFieldValue(field, propertyName, (ShuntCompensator) identifiable);
                 case BUS -> getBusFieldValue(field, (Bus) identifiable, propertyName);
-                case BUSBAR_SECTION -> getBusBarSectionFieldValue(field, (BusbarSection) identifiable);
+                case BUSBAR_SECTION -> getBusBarSectionFieldValue(field, propertyName, (BusbarSection) identifiable);
                 case BATTERY -> getBatteryFieldValue(field, propertyName, (Battery) identifiable);
                 case SUBSTATION -> getSubstationFieldValue(field, (Substation) identifiable);
                 case TWO_WINDINGS_TRANSFORMER -> getTwoWindingsTransformerFieldValue(field, propertyName, (TwoWindingsTransformer) identifiable);
@@ -240,12 +240,13 @@ public final class ExpertFilterUtils {
         };
     }
 
-    private static String getBusBarSectionFieldValue(FieldType field, BusbarSection busbarSection) {
+    private static String getBusBarSectionFieldValue(FieldType field, String propertyName, BusbarSection busbarSection) {
         return switch (field) {
             case COUNTRY,
                 NOMINAL_VOLTAGE,
                 VOLTAGE_LEVEL_ID,
-                SUBSTATION_ID -> getVoltageLevelFieldValue(field, null, busbarSection.getTerminal().getVoltageLevel());
+                SUBSTATION_ID,
+                SUBSTATION_PROPERTIES -> getVoltageLevelFieldValue(field, propertyName, busbarSection.getTerminal().getVoltageLevel());
             default -> throw new PowsyblException(FIELD_AND_TYPE_NOT_IMPLEMENTED + " [" + field + "," + busbarSection.getType() + "]");
         };
     }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

We want to filter contingencies on busbar sections in the security analysis results, using voltage level filters selected in the generic filters category.



